### PR TITLE
Write Plog Reactions

### DIFF
--- a/pymars/soln2cti.py
+++ b/pymars/soln2cti.py
@@ -115,9 +115,16 @@ def write(solution):
             string of equation type
         """
         if equation_type == 'PlogReaction':
-            pre_exponential_factor = equation_object[1].pre_exponential_factor
-            temperature_exponent = equation_object[1].temperature_exponent
-            activation_energy = (equation_object[1].activation_energy /
+            coeff_sum = equation_object[0]
+            equation_object = equation_object[1][1]
+            if coeff_sum == 1:
+                pre_exponential_factor = equation_object.pre_exponential_factor
+            if coeff_sum == 2:
+                pre_exponential_factor = equation_object.pre_exponential_factor*10**3
+            if coeff_sum == 3:
+                pre_exponential_factor = equation_object.pre_exponential_factor*10**6
+            temperature_exponent = equation_object.temperature_exponent
+            activation_energy = (equation_object.activation_energy /
                                  calories_constant)
         else:
             coeff_sum = sum(equation_object.reactants.values())
@@ -513,9 +520,10 @@ def write(solution):
             reaction_string = reaction_string.substitute(
                     m=m,
                     equation_string=equation_string)
+            sum_coeffs = sum(equation_object.reactants.values())
             for rate_line in equation_object.rates:
                 pressure = str('{:f}'.format(rate_line[0]/ct.one_atm))
-                arrhenius = build_arrhenius(rate_line, equation_type)
+                arrhenius = build_arrhenius((sum_coeffs,rate_line), equation_type)
                 arrhenius = arrhenius[1:-1]
                 reaction_string = Template(
                         reaction_string + 

--- a/pymars/soln2cti.py
+++ b/pymars/soln2cti.py
@@ -1,6 +1,6 @@
 """writes a solution object to a cantera cti file.
 
-currently only works for Elementary, Falloff and ThreeBody Reactions
+currently only works for Elementary, Falloff, Plog and ThreeBody Reactions
 Cantera development version 2.3.0a2 required
 """
 from __future__ import print_function

--- a/pymars/soln2cti.py
+++ b/pymars/soln2cti.py
@@ -448,7 +448,7 @@ def write(solution):
                     Arr=arrhenius,
                     Efficiencies=efficiencies_string
                     ))
-        if equation_type == 'ElementaryReaction':
+        elif equation_type == 'ElementaryReaction':
             arrhenius = build_arrhenius(equation_object, equation_type)
             if equation_object.duplicate is True:
                 reaction_string = Template(
@@ -466,7 +466,7 @@ def write(solution):
                     equation_string=equation_string,
                     Arr=arrhenius
                     ))
-        if equation_type == 'FalloffReaction':
+        elif equation_type == 'FalloffReaction':
             #trimms efficiencies list
             efficiencies = equation_object.efficiencies
             trimmed_efficiencies = equation_object.efficiencies
@@ -507,7 +507,7 @@ def write(solution):
                 f.write(falloff_str)
             except IndexError:
                 f.write('\n           )\n\n')
-        if equation_type == 'PlogReaction':
+        elif equation_type == 'PlogReaction':
             reaction_string = Template('#  Reaction $m\n' + \
                             'pdep_arrhenius( \"$equation_string\",\n')
             reaction_string = reaction_string.substitute(
@@ -530,6 +530,9 @@ def write(solution):
                 reaction_string = reaction_string[:-1]
                 reaction_string = reaction_string + ')\n\n'
             f.write(reaction_string)
+        else:
+            print('Error: Unknown reaction type')
+            exit()
     f.close()
     return output_file_name
 


### PR DESCRIPTION
soln2cti.py was not writing out Plog reactions. Added in that functionality and it now spits out an error if it doesn't recognize a reaction type, just in case there are other reactions that are missed.