### PR TITLE
Refactor Sensitivity Analysis and Implement DRGASA Reduction Method

### DIFF
--- a/pymars/drg.py
+++ b/pymars/drg.py
@@ -238,8 +238,10 @@ def run_drg(solution_object, conditions_file, error_limit, target_species,
         error, max_t, done, rate_edge_data,
         ignition_delay_detailed, conditions_array
         )
-    
-    return sol_new
+   
+    limbo = []
+    result = [sol_new, limbo]
+    return result
 
 
 def drg_loop_control(solution_object, target_species, retained_species, model_file, stored_error, threshold, done, rate_edge_data,

--- a/pymars/drg.py
+++ b/pymars/drg.py
@@ -161,11 +161,13 @@ def run_drg(solution_object, conditions_file, error_limit, target_species,
         The path to the file where the solution object was generated from
     final_error: singleton float
         To hold the error level of simulation
+    epsilon_star: float
+        Epsilon star value for sensativity analysis
 
     Returns
     -------
 
-    Writes reduced Cantera file and returns reduced Cantera solution object
+    Tuple of reduced Cantera solution object [0] and list of limbo species for SA [1]
 
     """
     
@@ -243,6 +245,7 @@ def run_drg(solution_object, conditions_file, error_limit, target_species,
             ignition_delay_detailed, conditions_array
             )
     
+        # Anything that was reduced at epstar threshold, add to limbo 
         for sp in sol_new.species_names:
             if sp not in epstar_sol.species_names:
                 limbo.append(sp)

--- a/pymars/drg.py
+++ b/pymars/drg.py
@@ -141,7 +141,7 @@ def trim_drg(total_edge_data, solution_object, threshold_value, keeper_list, don
 
 
 def run_drg(solution_object, conditions_file, error_limit, target_species,
-            retained_species, model_file, final_error):
+            retained_species, model_file, final_error, epsilon_star=.1):
     """
     Main function for running DRG reduction.
 
@@ -232,6 +232,22 @@ def run_drg(solution_object, conditions_file, error_limit, target_species,
         threshold += threshold_increment
         threshold = round(threshold, num_iterations)
 
+    limbo = []
+    if epsilon_star:
+        print("Calculating for DRGASA:")
+    
+        # Trim with ep star as threshold value and calculate error.
+        epstar_sol = drg_loop_control(
+            solution_object, target_species, retained_species, model_file,
+            error, epsilon_star, done, rate_edge_data,
+            ignition_delay_detailed, conditions_array
+            )
+    
+        for sp in sol_new.species_names:
+            if sp not in epstar_sol.species_names:
+                limbo.append(sp)
+
+
     print("Greatest result: ")
     sol_new = drg_loop_control(
         solution_object, target_species, retained_species, model_file,
@@ -239,7 +255,6 @@ def run_drg(solution_object, conditions_file, error_limit, target_species,
         ignition_delay_detailed, conditions_array
         )
    
-    limbo = []
     result = [sol_new, limbo]
     return result
 

--- a/pymars/drgep.py
+++ b/pymars/drgep.py
@@ -225,16 +225,16 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 			threshold = threshold + threshold_i
 			threshold = round(threshold, n)
 
+	print("\nGreatest result: ")
+	sol_new = drgep_loop_control(
+		solution_object, target_species, retained_species, model_file, error, max_t, done, max_dic, ignition_delay_detailed, conditions_array)
+
 	limbo = []
 	if ep_star:	
 		# If a species meets the limbo criteria, add it to limbo
 		for sp in sol_new.species_names:
 			if sp in max_dic and max_dic[sp] < ep_star and (not sp in limbo) and (not sp in retained_species):
 				limbo.append(sp)
-
-	print("\nGreatest result: ")
-	sol_new = drgep_loop_control(
-		solution_object, target_species, retained_species, model_file, error, max_t, done, max_dic, ignition_delay_detailed, conditions_array)
 
 	result = [sol_new, limbo]	
 	return result

--- a/pymars/drgep.py
+++ b/pymars/drgep.py
@@ -144,7 +144,7 @@ def trim_drgep(max_dic, solution_object, threshold_value, retained_species, done
     return exclusion_list
 
 
-def run_drgep(solution_object, conditions_file, error_limit, target_species, retained_species, model_file, final_error):
+def run_drgep(solution_object, conditions_file, error_limit, target_species, retained_species, model_file, final_error, ep_star):
     
 	""""
 	This is the MAIN top level function for running DRGEP
@@ -159,6 +159,7 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 	retained_species: An array of species that should not be removed from the model
 	model_file: The path to the file holding the original model
 	final_error: A singleton holding the final error percentage
+	ep_star: epsilon star value used for SA limbo calculations
 
 	Returns
 	-------
@@ -224,11 +225,17 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 			threshold = threshold + threshold_i
 			threshold = round(threshold, n)
 
+	limbo = []
+	for sp in sol_new.species_names:
+		if sp in max_dic and max_dic[sp] < ep_star and (not sp in limbo) and (not sp in retained_species):
+			limbo.append(sp)
+
 	print("\nGreatest result: ")
 	sol_new = drgep_loop_control(
 		solution_object, target_species, retained_species, model_file, error, max_t, done, max_dic, ignition_delay_detailed, conditions_array)
-	
-	return sol_new
+
+	result = [sol_new, limbo]	
+	return result
 
 
 def drgep_loop_control(solution_object, target_species, retained_species, model_file, stored_error, threshold, done, max_dic, ignition_delay_detailed, conditions_array):

--- a/pymars/drgep.py
+++ b/pymars/drgep.py
@@ -164,7 +164,7 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 	Returns
 	-------
 
-	Writes reduced Cantera file and returns reduced Catnera solution object
+	Tuple of reduced Catnera solution object [0] and limbo species for SA [1]
     
 	"""
 
@@ -226,6 +226,7 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 			threshold = round(threshold, n)
 
 	limbo = []
+	# If a species meets the limbo criteria, add it to limbo
 	for sp in sol_new.species_names:
 		if sp in max_dic and max_dic[sp] < ep_star and (not sp in limbo) and (not sp in retained_species):
 			limbo.append(sp)

--- a/pymars/drgep.py
+++ b/pymars/drgep.py
@@ -226,10 +226,11 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 			threshold = round(threshold, n)
 
 	limbo = []
-	# If a species meets the limbo criteria, add it to limbo
-	for sp in sol_new.species_names:
-		if sp in max_dic and max_dic[sp] < ep_star and (not sp in limbo) and (not sp in retained_species):
-			limbo.append(sp)
+	if ep_star:	
+		# If a species meets the limbo criteria, add it to limbo
+		for sp in sol_new.species_names:
+			if sp in max_dic and max_dic[sp] < ep_star and (not sp in limbo) and (not sp in retained_species):
+				limbo.append(sp)
 
 	print("\nGreatest result: ")
 	sol_new = drgep_loop_control(

--- a/pymars/pfa.py
+++ b/pymars/pfa.py
@@ -205,8 +205,10 @@ def run_pfa(solution_object, conditions_file, error_limit, target_species, retai
 	print("\nGreatest result: ")
 	sol_new = pfa_loop_control(
 		solution_object, target_species, retained_species, model_file, error, max_t, done, rate_edge_data, ignition_delay_detailed, conditions_array)
-	
-	return sol_new
+
+	limbo = []
+	result = [sol_new, limbo]	
+	return result
 
 
 def pfa_loop_control(solution_object, target_species, retained_species, model_file, stored_error, threshold, done, rate_edge_data, ignition_delay_detailed, conditions_array):

--- a/pymars/pymars.py
+++ b/pymars/pymars.py
@@ -57,6 +57,7 @@ def pymars(model_file, conditions, error, method, target_species,
     elif method == 'DRGEP':
         result = run_drgep(solution_object, conditions, error, target_species, retained_species, model_file, final_error, epsilon_star)
 
+    # Result object is split into the model [0] and limbo species if SA will be ran [1]
     reduced_model = result[0]
     limbo = result[1]
 

--- a/pymars/pymars.py
+++ b/pymars/pymars.py
@@ -51,13 +51,16 @@ def pymars(model_file, conditions, error, method, target_species,
     final_error = [0]
     
     if method == 'DRG':
-        reduced_model = run_drg(solution_object, conditions, error, target_species, retained_species, model_file, final_error)
+        result = run_drg(solution_object, conditions, error, target_species, retained_species, model_file, final_error)
     elif method == 'PFA':
-        reduced_model = run_pfa(solution_object, conditions, error, target_species, retained_species, model_file, final_error)
+        result = run_pfa(solution_object, conditions, error, target_species, retained_species, model_file, final_error)
     elif method == 'DRGEP':
-        reduced_model = run_drgep(solution_object, conditions, error, target_species, retained_species, model_file, final_error)
+        result = run_drgep(solution_object, conditions, error, target_species, retained_species, model_file, final_error, epsilon_star)
+
+    reduced_model = result[0]
+    limbo = result[1]
 
     if run_sensitivity_analysis:
-        reduced_model = run_sa(solution_object, reduced_model, epsilon_star, final_error, conditions, target_species, retained_species, error)
+        reduced_model = run_sa(solution_object, reduced_model, final_error, conditions, target_species, retained_species, error, limbo)
    
     output_file = soln2cti.write(reduced_model)

--- a/pymars/pymars.py
+++ b/pymars/pymars.py
@@ -51,7 +51,7 @@ def pymars(model_file, conditions, error, method, target_species,
     final_error = [0]
     
     if method == 'DRG':
-        result = run_drg(solution_object, conditions, error, target_species, retained_species, model_file, final_error)
+        result = run_drg(solution_object, conditions, error, target_species, retained_species, model_file, final_error, epsilon_star)
     elif method == 'PFA':
         result = run_pfa(solution_object, conditions, error, target_species, retained_species, model_file, final_error)
     elif method == 'DRGEP':

--- a/pymars/sensitivity_analysis.py
+++ b/pymars/sensitivity_analysis.py
@@ -1,6 +1,5 @@
 from create_trimmed_model import trim
 from simulation import Simulation
-from drgep import make_dic_drgep
 from drgep import get_rates
 from readin_initial_conditions import readin_conditions
 import numpy as np
@@ -38,18 +37,22 @@ def get_limbo_dic(original_model, reduced_model, limbo, final_error, id_detailed
 	og_sn = []
 	new_sn = []
 
+	# Append species names
 	species_objex = reduced_model.species()
 	for sp in species_objex:
 		new_sn.append(sp.name)
 
+	# Append species names
 	species_objex = original_model.species()
 	for sp in species_objex:
 		og_sn.append(sp.name)
 
+	# If its in original model, and new model then keep
 	for sp in og_sn:
 		if sp in new_sn:
 			keep.append(sp)
-
+	
+	# If its not being kept, exclude (all that were removed in original reduction)
 	for sp in original_model.species():
 		if not (sp.name in keep):
 			og_excl.append(sp.name)
@@ -147,18 +150,22 @@ def run_sa(original_model, reduced_model, final_error, conditions_file, target, 
 		keep = []  # Species retained from removals
 		og_excl = []  # Species that will be excluded from the final model (Reduction will be preformed on original model)
 
+		# Append species names
 		species_objex = old.species()
 		for sp in species_objex:
 			new_sn.append(sp.name)
 
+		# Append species names
 		species_objex = original_model.species()
 		for sp in species_objex:
 			og_sn.append(sp.name)
 
+		# If its in original model, and new model
 		for sp in og_sn:
 			if sp in new_sn:
 				keep.append(sp)
 
+		# If its not being kept, exclude (all that were removed in original reduction)
 		for sp in original_model.species():
 			if not (sp.name in keep):
 				og_excl.append(sp.name)
@@ -173,7 +180,7 @@ def run_sa(original_model, reduced_model, final_error, conditions_file, target, 
 		dic = get_limbo_dic(original_model,old,limbo,final_error, id_detailed,conditions_array)
 		rm = dic_lowest(dic)  # Species that should be removed (Lowest error).
 		exclude = [rm]
-		limbo.remove(rm)
+		limbo.remove(rm) # Remove species from limbo
 
 		for sp in og_excl:  # Add to list of species that should be excluded from final model.
 			exclude.append(sp)

--- a/pymars/sensitivity_analysis.py
+++ b/pymars/sensitivity_analysis.py
@@ -136,8 +136,6 @@ def run_sa(original_model, reduced_model, final_error, conditions_file, target, 
 
 	rate_edge_data = get_rates(sim_array, original_model) # Get edge weight calculation data.
 	
-	# Make a dictionary of overall interaction coefficients.
-	drgep_coeffs = make_dic_drgep(original_model, rate_edge_data, target)
 	if (id_detailed.all() == 0): # Ensure that ignition occured
 		print("Original model did not ignite.  Check initial conditions.")
 		exit()

--- a/pymars/sensitivity_analysis.py
+++ b/pymars/sensitivity_analysis.py
@@ -1,3 +1,5 @@
+import cantera as ct
+
 from create_trimmed_model import trim
 from simulation import Simulation
 from drgep import get_rates
@@ -67,7 +69,13 @@ def get_limbo_dic(original_model, reduced_model, limbo, final_error, id_detailed
 
 		# Simulated reduced solution
 		new_sim = helper.setup_simulations(conditions_array,new_sol) # Create simulation objects for reduced model for all conditions
-		id_new = helper.simulate(new_sim) # Run simulations and process results
+	
+		try:	
+			id_new = helper.simulate(new_sim) # Run simulations and process results
+		except ct.CanteraError:
+			limbo.remove(sp)
+			id_new = 0
+	
 		error = (abs(id_new - id_detailed)/id_detailed)*100
 		error = round(np.max(error), 2)
 		print(sp + ": " + str(error))

--- a/pymars/tests/test_methods.py
+++ b/pymars/tests/test_methods.py
@@ -81,7 +81,7 @@ def testPFA():
 	assert reduced_model.species_names == expected_model.species_names
 	assert len(reduced_model.reactions()) == len(expected_model.reactions())
 
-def testDRG():
+def testDRGASA():
 
 	# Original model
 	path_to_original = relative_location("example_files/gri30.cti")
@@ -96,12 +96,25 @@ def testDRG():
 	epsilon_star = .5
 
 	# Run DRG
-	reduced_model = drg.run_drg(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error)[0]
+	result = drg.run_drg(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error, epsilon_star)
+	reduced_model = result[0]
+	limbo = result[1]
 
 	# Expected answer	
 	path_to_answer = relative_location("pymars/tests/drg_gri30.cti")
 	expected_model = ct.Solution(path_to_answer)
 
 	# Make sure models are the same
+	assert reduced_model.species_names == expected_model.species_names
+	assert len(reduced_model.reactions()) == len(expected_model.reactions())
+	
+	# Run SA	
+	reduced_model = sensitivity_analysis.run_sa(solution_object, reduced_model, final_error, conditions, target_species, retained_species, error, limbo)
+
+	# Get expected model	
+	path_to_answer = relative_location("pymars/tests/drgasa_gri30.cti")
+	expected_model = ct.Solution(path_to_answer)
+
+	# Make sure models are the same	
 	assert reduced_model.species_names == expected_model.species_names
 	assert len(reduced_model.reactions()) == len(expected_model.reactions())

--- a/pymars/tests/test_methods.py
+++ b/pymars/tests/test_methods.py
@@ -32,7 +32,9 @@ def testDRGEPSA():
 	epsilon_star = .5
 
 	# Run DRGEP
-	reduced_model = drgep.run_drgep(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error)
+	result = drgep.run_drgep(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error, epsilon_star)
+	reduced_model = result[0]
+	limbo = result[1]
 
 	# Expected answer	
 	path_to_answer = relative_location("pymars/tests/drgep_gri30.cti")
@@ -43,7 +45,7 @@ def testDRGEPSA():
 	assert len(reduced_model.reactions()) == len(expected_model.reactions())
 
 	# Run SA	
-	reduced_model = sensitivity_analysis.run_sa(solution_object, reduced_model, epsilon_star, final_error, conditions, target_species, retained_species, error)
+	reduced_model = sensitivity_analysis.run_sa(solution_object, reduced_model, final_error, conditions, target_species, retained_species, error, limbo)
 
 	# Get expected model	
 	path_to_answer = relative_location("pymars/tests/sa_gri30.cti")
@@ -69,7 +71,7 @@ def testPFA():
 	epsilon_star = .5
 
 	# Run PFA
-	reduced_model = pfa.run_pfa(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error)
+	reduced_model = pfa.run_pfa(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error)[0]
 
 	# Expected answer	
 	path_to_answer = relative_location("pymars/tests/pfa_gri30.cti")
@@ -94,7 +96,7 @@ def testDRG():
 	epsilon_star = .5
 
 	# Run DRG
-	reduced_model = drg.run_drg(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error)
+	reduced_model = drg.run_drg(solution_object, conditions, error, target_species, retained_species, path_to_original, final_error)[0]
 
 	# Expected answer	
 	path_to_answer = relative_location("pymars/tests/drg_gri30.cti")


### PR DESCRIPTION
Related to issue #39.  Sensitivity Analysis has been refactored so limbo is passed in rather than calculated.  It is now the responsibility of each individual method to return a list of species in limbo with the reduced model.  The limbo list is given to the sensitivity analysis function as input.  DRGEPSA and DRG both calculate limbo species as needed.  DRGASA has been added on to the DRG test.  