### PR TITLE
Add "negative_A" option if required in cti files

### DIFF
--- a/pymars/soln2cti.py
+++ b/pymars/soln2cti.py
@@ -432,7 +432,10 @@ def write(solution, output_filename='', path=''):
                 raise NotImplementedError(f'Unsupported reaction type: {type(reaction)}')
             
             if reaction.duplicate:
-                reaction_string += ',\n' + indent[8] + 'options = "duplicate"'
+                if getattr(reaction, 'allow_negative_pre_exponential_factor', default=False):
+                    reaction_string += ',\n' + indent[8] + 'options = ["negative_A", "duplicate"]'
+                else:
+                    reaction_string += ',\n' + indent[8] + 'options = "duplicate"'
                                 
             reaction_string += ')\n\n'
             the_file.write(reaction_string)

--- a/pymars/soln2cti.py
+++ b/pymars/soln2cti.py
@@ -432,7 +432,7 @@ def write(solution, output_filename='', path=''):
                 raise NotImplementedError(f'Unsupported reaction type: {type(reaction)}')
             
             if reaction.duplicate:
-                if getattr(reaction, 'allow_negative_pre_exponential_factor', default=False):
+                if getattr(reaction, 'allow_negative_pre_exponential_factor', False):
                     reaction_string += ',\n' + indent[8] + 'options = ["negative_A", "duplicate"]'
                 else:
                     reaction_string += ',\n' + indent[8] + 'options = "duplicate"'


### PR DESCRIPTION
If a reaction has a negative pre-exponential factor, it must have a negative_A option in the cti file.
Fixes #67

Suggested by @rwest
Not yet properly tested