### PR TITLE
Update docs for conda-forge recipe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,19 +10,31 @@ You can find a [list of current issues](https://github.com/Niemeyer-Research-Gro
  * Explain the behavior you expected, and how what you got differed.
  * Include the full text of any error messages that are printed on the screen.
 
+## Development setup
+
+We recommend working inside an isolated environment (see the [installation guide](https://Niemeyer-Research-Group.github.io/pyMARS/installation.html)). Clone the repository, install pyMARS with its development dependencies, and set up the pre-commit hooks:
+
+    git clone https://github.com/Niemeyer-Research-Group/pyMARS.git
+    cd pyMARS
+    pip install -e .[dev]
+    pre-commit install
+
 ## Pull Requests
 
  * If you're unfamiliar with Pull Requests, please take a look at the [GitHub documentation for them](https://help.github.com/articles/proposing-changes-to-a-project-with-pull-requests/).
- * **Make sure the test suite passes** on your computer, and that test coverage doesn't go down. To do this, run `pytest -vv --cov=./` from the top-level directory. The test suite is currently a work in progess.
+ * Start by creating a new branch from the latest commit on [`main`](https://github.com/Niemeyer-Research-Group/pyMARS/tree/main).
+ * **Make sure the test suite passes** and that test coverage doesn't go down. From the top-level directory, run `pytest --cov=pymars`.
  * *Always* add tests and docs for your code.
- * The use of emoji in Pull Requests is encouraged with the format ":emoji: Commit summary". See [this list of suggested emoji.](https://github.com/slashsBin/styleguide-git-commit-message#suggested-emojis)
- * Please reference relevant GitHub issues in your commit messages using `GH123` or `#123`.
- * Changes should be [PEP8](https://www.python.org/dev/peps/pep-0008/) and [PEP257](https://www.python.org/dev/peps/pep-0257/) compatible.
- * Keep style fixes to a separate commit to make your pull request more readable.
- * Add your changes into the [`CHANGELOG`](https://github.com/Niemeyer-Research-Group/pyMARS/blob/master/CHANGELOG.md)
- * Docstrings are required and should follow the [Google style](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
- * When you start working on a pull request, start by creating a new branch pointing at the latest commit on [GitHub master](https://github.com/Niemeyer-Research-Group/pyMARS/tree/master).
- * The copyright policy is detailed in the [`LICENSE`](https://github.com/Niemeyer-Research-Group/pyMARS/blob/master/LICENSE).
+ * Code style is enforced with [Black](https://black.readthedocs.io/) and [Ruff](https://docs.astral.sh/ruff/) via [pre-commit](https://pre-commit.com/). Run `pre-commit run --all-files` (or install the hooks as shown above) before pushing.
+ * Docstrings are required and should follow the [NumPy style](https://numpydoc.readthedocs.io/en/latest/format.html).
+ * Add an entry describing your changes to the [`CHANGELOG`](https://github.com/Niemeyer-Research-Group/pyMARS/blob/main/CHANGELOG.md), under the `Unreleased` section.
+ * The use of emoji in Pull Request titles is encouraged, with the format ":emoji: Commit summary". See [this list of suggested emoji](https://github.com/slashsBin/styleguide-git-commit-message#suggested-emojis).
+ * Please reference relevant GitHub issues in your commit messages using `#123`.
+ * The copyright policy is detailed in the [`LICENSE`](https://github.com/Niemeyer-Research-Group/pyMARS/blob/main/LICENSE).
+
+## Releasing
+
+If you're a maintainer cutting a new release, see [`RELEASING.md`](RELEASING.md) for the step-by-step checklist (version bump, changelog, tagging, and publishing to PyPI and conda-forge).
 
 ## Meta
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing a new version
+
+This is the maintainer checklist for cutting a new pyMARS release. Releases are
+published to **PyPI** (as `nrg-pymars`) and **conda-forge**; the import package
+and command-line tool are named `pymars`.
+
+## Prerequisites (one-time setup)
+
+- **PyPI:** OIDC trusted publishing is configured for the `nrg-pymars` project,
+  tied to this repository's `publish.yml` workflow and the `pypi` environment.
+- **conda-forge:** the `nrg-pymars-feedstock` exists (created automatically after
+  the `conda-forge/staged-recipes` PR is merged).
+
+## Release steps
+
+1. Make sure `main` is green (CI passing).
+
+2. Bump the version in `src/pymars/_version.py`. This is the single source of
+   truth — `pyproject.toml`, the conda recipe, and the docs all read from it.
+
+3. Update `CHANGELOG.md`: move the entries under `## [Unreleased]` into a new
+   `## [X.Y.Z] - YYYY-MM-DD` section, and add the matching compare link at the
+   bottom of the file.
+
+4. Update `CITATION.cff`: set `version` and `date-released`.
+
+5. Open a pull request with the above changes, wait for CI to pass, and merge it
+   (branch protection requires a PR to land on `main`).
+
+6. Tag the merge commit on `main` and push the tag:
+
+   ```bash
+   git switch main
+   git pull upstream main
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push upstream vX.Y.Z
+   ```
+
+   Pushing the tag triggers `.github/workflows/publish.yml`, which runs the CI
+   test suite first and then, only if it passes, builds and publishes to PyPI.
+
+7. **conda-forge** (mostly automatic): within a few hours of the PyPI release,
+   the conda-forge autotick bot opens a version-bump pull request on the
+   `nrg-pymars-feedstock` repository, updating the version and sha256. Review and
+   merge it; conda-forge CI then builds and publishes to the `conda-forge`
+   channel. You only need to edit the recipe yourself if the dependencies or the
+   minimum Python version changed.
+
+8. (Optional) Create a GitHub Release for the tag, using the new `CHANGELOG.md`
+   section as the release notes.
+
+9. Verify the release:
+
+   ```bash
+   pip install nrg-pymars==X.Y.Z
+   # once the conda-forge build completes:
+   conda install -c conda-forge nrg-pymars
+   ```
+
+## TODO: clean up once the conda-forge package is live
+
+The self-hosted Anaconda.org build is redundant once `nrg-pymars` is on
+conda-forge. After the feedstock is publishing, do the following:
+
+- [ ] Remove the `conda` job from `.github/workflows/publish.yml` (the
+      Anaconda.org build + upload to the `niemeyer-research-group` channel).
+- [ ] Remove `conda.recipe/` (the self-hosted recipe) if nothing else uses it.
+- [ ] Update the conda install instructions in `README.md` and
+      `docs/installation.rst` to `conda install -c conda-forge nrg-pymars`.
+- [ ] Remove the `ANACONDA_API_TOKEN` repository secret once nothing references it.
+- [ ] Update this file to drop the Anaconda.org references above.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,8 @@ and command-line tool are named `pymars`.
    `## [X.Y.Z] - YYYY-MM-DD` section, and add the matching compare link at the
    bottom of the file.
 
-4. Update `CITATION.cff`: set `version` and `date-released`.
+4. Update `CITATION.cff`: set `version` and `date-released`. Also update the
+   version in `CITATION.md`.
 
 5. Open a pull request with the above changes, wait for CI to pass, and merge it
    (branch protection requires a PR to land on `main`).
@@ -46,16 +47,20 @@ and command-line tool are named `pymars`.
    channel. You only need to edit the recipe yourself if the dependencies or the
    minimum Python version changed.
 
-8. (Optional) Create a GitHub Release for the tag, using the new `CHANGELOG.md`
-   section as the release notes.
-
-9. Verify the release:
+8. Verify the release:
 
    ```bash
    pip install nrg-pymars==X.Y.Z
    # once the conda-forge build completes:
    conda install -c conda-forge nrg-pymars
    ```
+
+9. Create a GitHub Release for the tag, using the new `CHANGELOG.md`
+   section as the release notes.
+
+10. A few minutes after the GitHub Release is published, Zenodo should archive it
+   and mint a new DOI. <https://zenodo.org/badge/latestdoi/51664233> should point
+   to the latest DOI; grab that, and update in `CITATION.cff` and `CITATION.md`.
 
 ## TODO: clean up once the conda-forge package is live
 


### PR DESCRIPTION
WIP, do not merge until conda-forge recipe PR is merged: https://github.com/conda-forge/staged-recipes/pull/33909

- adds RELEASING.md with checklist for new releases
- updates CONTRIBUTING.md to reflect updates

To do once conda-forge recipe is merged:
- [ ] Remove the `conda` job from `.github/workflows/publish.yml` (the
      Anaconda.org build + upload to the `niemeyer-research-group` channel).
- [ ] Remove `conda.recipe/` (the self-hosted recipe) if nothing else uses it.
- [ ] Update the conda install instructions in `README.md` and
      `docs/installation.rst` to `conda install -c conda-forge nrg-pymars`.
- [ ] Remove the `ANACONDA_API_TOKEN` repository secret once nothing references it.
- [ ] Update this file to drop the Anaconda.org references above.